### PR TITLE
fix: duplicate keys by converting addresses to lowercase

### DIFF
--- a/.changeset/thirty-jobs-buy.md
+++ b/.changeset/thirty-jobs-buy.md
@@ -1,0 +1,5 @@
+---
+'@protocolink/logics': patch
+---
+
+fix paraswap token list

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -95,10 +95,19 @@ export async function getTokenList(
   const tokenList: common.Token[] = [...defaultTokenList];
   for (const { tokens } of tokenLists) {
     for (const { chainId, address, decimals, symbol, name } of tokens) {
-      if (tmp[address] || chainId !== chainIdInput || !name || !symbol || !decimals || !ethers.utils.isAddress(address))
+      const lowerCaseAddress = address.toLowerCase();
+
+      if (
+        tmp[lowerCaseAddress] ||
+        chainId !== chainIdInput ||
+        !name ||
+        !symbol ||
+        !decimals ||
+        !ethers.utils.isAddress(address)
+      )
         continue;
       tokenList.push(new common.Token(chainId, address, decimals, symbol, name));
-      tmp[address] = true;
+      tmp[lowerCaseAddress] = true;
     }
   }
 


### PR DESCRIPTION
- [x] fix paraswap token list
- [x] yarn changeset